### PR TITLE
Use newer appimagetool, drop `libfuse2` as dependency.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Download Brave
         continue-on-error: true
         run: |
+          # Install appimagetool dependency
+          sudo apt-get -y install desktop-file-utils
+
           set -u
 
           # --------------------------- #
@@ -111,12 +114,12 @@ jobs:
                   ls -al "$APPDIR"
 
                   wget -q --show-progress --progress=dot:mega -O appimagetool \
-                      https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+                      https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
                   chmod +x ./appimagetool
 
                   ./appimagetool --appimage-extract && mv ./squashfs-root ./appimagetool.AppDir
 
-                  ./appimagetool.AppDir/AppRun --comp gzip "$APPDIR" -n -u \
+                  ./appimagetool.AppDir/AppRun --comp zstd "$APPDIR" -n -u \
                       "gh-releases-zsync|$GITHUB_REPOSITORY_OWNER|Brave-AppImage|$TYPE|Brave*.AppImage.zsync" \
                       "Brave-$TYPE-$TAG-x86_64.AppImage"
 


### PR DESCRIPTION
This change drops `libfuse2` dependency from the appimage and it now uses zstd compression.

Fixes #10 

Back when I made the issue there was only go-appimegtool, but recently [Appimage/appimagetool](https://github.com/AppImage/appimagetool) was updated with the same changes, which is nice because this one is more compatible with the older appimagetool options.